### PR TITLE
Update Worker.cs so it stops gracefully

### DIFF
--- a/Signal.Beacon.WorkerService/Worker.cs
+++ b/Signal.Beacon.WorkerService/Worker.cs
@@ -95,7 +95,7 @@ namespace Signal.Beacon.WorkerService
 
             // Wait for cancellation token
             while (!stoppingToken.IsCancellationRequested)
-                await Task.Delay(-1, stoppingToken);
+                await Task.WhenAny(Task.Delay(-1, stoppingToken));
 
             // Stop services
             await Task.WhenAll(this.workerServices.Value.Select(this.StopWorkerService));


### PR DESCRIPTION
Task.Delay will throw a TaskCanceledException so the code after it will never execute.
The proposed code is a one liner that will swallow the exception, you can ofc use try-catch or ContinueWith or something else perhaps.